### PR TITLE
docs: mark repo out of scope for HackerOne

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A universal TypeScript GraphQL client for the Stellar Wallet Backend with optional JWT authentication. Works seamlessly in Node.js, browsers, React, and React Native environments.
 
+> **Security Policy**: This repository is **out of scope** for the [Stellar HackerOne program](https://hackerone.com/stellar). It is **not currently under active development**. Please do not submit vulnerability reports against this repository.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## What

Adds a **Security Policy** notice to the top of the README stating that this repository is **out of scope** for the [Stellar HackerOne program](https://hackerone.com/stellar), and does **not** receive security patches.

## Why

This client is not actively maintained and is out of sync with the current `stellar/wallet-backend` server. A visible policy notice directs reporters away from filing vulnerability reports, and moves it out of HackerOne coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)